### PR TITLE
add piwheels pip index url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /pip-dependencies
 RUN pip install --upgrade pip setuptools wheel
 COPY pyproject.toml .
 COPY setup.py .
-RUN pip install .
+RUN pip install --extra-index-url https://www.piwheels.org/simple .
 
 FROM python:3.8-slim as prod
 RUN apt-get update && apt-get -y install \


### PR DESCRIPTION
[piwheels](https://www.piwheels.org/) apparently has python wheels prebuilt for pis, so it should speed up the deploy action a bit.