### PR TITLE
:sparkles: shuffle Tito reaction order

### DIFF
--- a/duckbot/cogs/tito/tito.py
+++ b/duckbot/cogs/tito/tito.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 
 from discord.ext import commands
 
@@ -13,7 +14,7 @@ class Tito(commands.Cog):
     async def react_to_tito_with_yugoslavia(self, message):
         """Adds reactions for all formally Yugoslavian country flags when :tito: is sent."""
         if ":tito:" in message.content:
-            await asyncio.gather(*[message.add_reaction(f) for f in flags])
+            await asyncio.gather(*[message.add_reaction(f) for f in random.sample(flags, len(flags))])
 
     @commands.Cog.listener("on_raw_reaction_add")
     async def react_to_tito_reaction(self, payload):
@@ -21,4 +22,4 @@ class Tito(commands.Cog):
         if payload.emoji.name == "tito":
             channel = await self.bot.fetch_channel(payload.channel_id)
             message = await channel.fetch_message(payload.message_id)
-            await asyncio.gather(*[message.add_reaction(f) for f in flags])
+            await asyncio.gather(*[message.add_reaction(f) for f in random.sample(flags, len(flags))])


### PR DESCRIPTION
##### Summary

The Tito cog reacts to `:tito:` with the seven post-Yugoslav country flags. The list is iterated in the same order every time, so Discord renders the reactions in a fixed sequence. This shuffles the order per invocation using `random.sample(flags, len(flags))`, which returns a shuffled copy without mutating the module-level `flags` constant. All seven flags are still sent every time — only the order changes.

Manual testing: ran `pytest tests/cogs/tito/` (existing assertions use `any_order=True`, so they still pass). Have not smoke-tested in Discord yet.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [ ] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [ ] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)