### PR TITLE
:white_check_mark: Run alembic migrations in tests, compare schema to models

### DIFF
--- a/tests/cogs/weather/weather_test.py
+++ b/tests/cogs/weather/weather_test.py
@@ -126,6 +126,22 @@ async def test_set_default_location_location_not_saved(weather, session, context
     session.commit.assert_not_called()
 
 
+async def test_set_default_location_round_trip(bot, in_memory_db, context):
+    async def mock_search_location(context, city, country, index):
+        return Location(city, 1, 1, 1, country="CA")
+
+    clazz = Weather(bot, in_memory_db)
+    clazz.search_location = mock_search_location
+    context.author.id = 123
+    await clazz.set_default_location(context, "city", None, None)
+    await clazz.set_default_location(context, "new city", None, None)  # merge upserts on the same author id
+
+    with in_memory_db.session(SavedLocation) as session:
+        assert session.query(SavedLocation).count() == 1
+        saved = session.get(SavedLocation, 123)
+    assert (saved.name, saved.country, saved.latitude, saved.longitude) == ("new city", "CA", 1.0, 1.0)
+
+
 async def test_send_weather_no_default_no_args(weather, session, context):
     session.get.return_value = None
     await weather.send_weather(context, None, None, None)

--- a/tests/db/migrations_test.py
+++ b/tests/db/migrations_test.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.autogenerate import compare_metadata
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy import create_engine
+
+import duckbot.db
+from duckbot.cogs.playmarket.models import Base as PlayMarketBase
+from duckbot.cogs.weather.saved_location import Base as WeatherBase
+
+
+def test_migrations_produce_model_schema(tmp_path, monkeypatch):
+    """Upgrading to head yields the same schema as the models; sqlite only, so postgres-specific drift can slip by."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)  # env.py overrides the url when set
+    url = f"sqlite:///{tmp_path / 'migrated.db'}"
+    cfg = Config()
+    cfg.set_main_option("script_location", str(Path(duckbot.db.__file__).parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        context = MigrationContext.configure(conn, opts={"compare_type": True})
+        diffs = compare_metadata(context, [WeatherBase.metadata, PlayMarketBase.metadata])
+    assert diffs == []

--- a/tests/db/migrations_test.py
+++ b/tests/db/migrations_test.py
@@ -24,4 +24,5 @@ def test_migrations_produce_model_schema(tmp_path, monkeypatch):
     with engine.connect() as conn:
         context = MigrationContext.configure(conn, opts={"compare_type": True})
         diffs = compare_metadata(context, [WeatherBase.metadata, PlayMarketBase.metadata])
+    engine.dispose()
     assert diffs == []

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -43,4 +43,6 @@ class InMemoryDatabase:
 @pytest.fixture
 def in_memory_db():
     """Returns a real database backed by in-memory SQLite, for cogs whose logic is worth testing against real rows."""
-    return InMemoryDatabase()
+    database = InMemoryDatabase()
+    yield database
+    database.engine.dispose()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import call
-
 import pytest
 
 import duckbot.util.connection_test
@@ -31,6 +29,7 @@ def assert_extensions_loaded(bot_spy, additional_extensions=[]):
         "duckbot.logs",
         "duckbot.health",
         "duckbot.slash",
+        "duckbot.cogs.ai",
         "duckbot.cogs.announce_day",
         "duckbot.cogs.audio",
         "duckbot.cogs.corrections",
@@ -44,10 +43,12 @@ def assert_extensions_loaded(bot_spy, additional_extensions=[]):
         "duckbot.cogs.insights",
         "duckbot.cogs.math",
         "duckbot.cogs.messages",
+        "duckbot.cogs.playmarket",
         "duckbot.cogs.recipe",
         "duckbot.cogs.robot",
         "duckbot.cogs.text",
         "duckbot.cogs.tito",
         "duckbot.cogs.weather",
     ]
-    bot_spy.load_extension.assert_has_calls([call(x) for x in extensions + additional_extensions], any_order=True)
+    loaded = [c.args[0] for c in bot_spy.load_extension.call_args_list]
+    assert sorted(loaded) == sorted(extensions + additional_extensions)


### PR DESCRIPTION
## Summary
- **New `tests/db/migrations_test.py`**: runs `alembic upgrade head` against a temp SQLite file, then asserts `compare_metadata` reports zero diffs between the migrated schema and the SQLAlchemy models. Migrations were previously never executed by any test (all test schemas come from `metadata.create_all`), so model↔migration drift was invisible until production `migrate()`. Verified it detects drift: adding a column to a model fails the test with a readable `add_column` diff.
- **`tests/main_test.py`**: the extension assertion now compares the full loaded list exactly instead of `assert_has_calls` (which tolerates omissions) — the hardcoded list had silently drifted, missing `playmarket` and `ai`. The list stays hardcoded on purpose as a change-detector: a new cog fails the test until deliberately added.
- **`tests/cogs/weather/weather_test.py`**: one real-rows round-trip test on the shared `in_memory_db` fixture, covering the `session.merge` upsert semantics that the existing mock-based assertions can't validate.

Draft PR against the fork to run the full suite in Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)