### PR TITLE
:alarm_clock: align market seasons to calendar quarters

### DIFF
--- a/duckbot/cogs/playmarket/config.py
+++ b/duckbot/cogs/playmarket/config.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 
 STARTING_BALANCE = 10_000
-SEASON_LENGTH = timedelta(days=182)  # ~6 months
 SETTLEMENT_GRACE = timedelta(days=7)
 
 TOPUP_THRESHOLD = 1_000

--- a/duckbot/cogs/playmarket/config.py
+++ b/duckbot/cogs/playmarket/config.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 
 STARTING_BALANCE = 10_000
-SETTLEMENT_GRACE = timedelta(days=7)
 
 TOPUP_THRESHOLD = 1_000
 TOPUP_TARGET = 2_000

--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -29,6 +29,14 @@ def _whole(value) -> int:
     return math.floor(value)
 
 
+def _next_quarter_start(dt):
+    """Midnight on the first day of the calendar quarter following dt."""
+    month = (dt.month - 1) // 3 * 3 + 4
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    return dt.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
 class PlayMarket(commands.Cog):
     def __init__(self, bot, db: Database):
         self.bot = bot
@@ -262,14 +270,15 @@ class PlayMarket(commands.Cog):
         for rank, account in enumerate(sorted(accounts, key=lambda a: a.balance, reverse=True), start=1):
             session.add(SeasonResult(season_id=season.id, user_id=account.id, final_balance=account.balance, rank=rank))
         season.status = "archived"
-        next_season = self._new_season(session)
+        next_season = self._new_season(session, starts_at=season.ends_at)  # keep the calendar alignment even if settlement ran late
         for account in accounts:
             account.balance = 0
             self._credit(session, next_season.id, account, None, config.STARTING_BALANCE, "season_grant")
 
-    def _new_season(self, session) -> Season:
+    def _new_season(self, session, starts_at=None) -> Season:
+        starts_at = starts_at or now()
         count = session.query(Season).count()
-        season = Season(name=f"Season {count + 1}", starts_at=now(), ends_at=now() + config.SEASON_LENGTH, status="active", starting_balance=config.STARTING_BALANCE)
+        season = Season(name=f"Season {count + 1}", starts_at=starts_at, ends_at=_next_quarter_start(starts_at), status="active", starting_balance=config.STARTING_BALANCE)
         session.add(season)
         session.flush()  # assign id
         return season

--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -29,14 +29,6 @@ def _whole(value) -> int:
     return math.floor(value)
 
 
-def _next_quarter_start(dt):
-    """Midnight on the first day of the calendar quarter following dt."""
-    month = (dt.month - 1) // 3 * 3 + 4
-    year = dt.year + (month - 1) // 12
-    month = (month - 1) % 12 + 1
-    return dt.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
-
-
 class PlayMarket(commands.Cog):
     def __init__(self, bot, db: Database):
         self.bot = bot
@@ -278,7 +270,7 @@ class PlayMarket(commands.Cog):
     def _new_season(self, session, starts_at=None) -> Season:
         starts_at = starts_at or now()
         count = session.query(Season).count()
-        season = Season(name=f"Season {count + 1}", starts_at=starts_at, ends_at=_next_quarter_start(starts_at), status="active", starting_balance=config.STARTING_BALANCE)
+        season = Season(name=f"Season {count + 1}", starts_at=starts_at, status="active", starting_balance=config.STARTING_BALANCE)
         session.add(season)
         session.flush()  # assign id
         return season

--- a/duckbot/cogs/playmarket/market.py
+++ b/duckbot/cogs/playmarket/market.py
@@ -52,7 +52,6 @@ class PlayMarket(commands.Cog):
         """Roll the season over when its time comes; markets are resolved by their creators."""
         with self.db.session(Season) as session:
             self.active_season(session)
-            self.settle_season_if_due(session)
             session.commit()
 
     # --- command group ----------------------------------------------------
@@ -141,8 +140,6 @@ class PlayMarket(commands.Cog):
         b = config.LIQUIDITY[liquidity]
         with self.db.session(Season) as session:
             season = self.active_season(session)
-            if season.status != "active":
-                return await context.send("Season's wrapping up, no new markets. Pump the brakes.")
             self.account(session, season.id, context.author.id)  # ensure creator has an account
             market = Market(season_id=season.id, creator_id=context.author.id, question=question, b=b, subsidy=_whole(lmsr.subsidy(b)))
             session.add(market)
@@ -243,29 +240,27 @@ class PlayMarket(commands.Cog):
     # --- season lifecycle -------------------------------------------------
 
     def active_season(self, session) -> Season:
-        """The active or settling season; creates Season 1 on first use, flips ended ones to settling."""
-        season = session.query(Season).filter(Season.status.in_(("active", "settling"))).order_by(Season.id.desc()).first()
+        """The active season; creates Season 1 on first use, rolling over an expired one immediately."""
+        season = session.query(Season).filter_by(status="active").order_by(Season.id.desc()).first()
         if season is None:
             return self._new_season(session)
-        if season.status == "active" and now() >= season.ends_at:
-            season.status = "settling"
+        if now() >= season.ends_at:
+            return self._rollover(session, season)
         return season
 
-    def settle_season_if_due(self, session):
-        """After the grace period, void unresolved markets and roll over to the next season."""
-        season = session.query(Season).filter_by(status="settling").first()
-        if season is None or now() < season.ends_at + config.SETTLEMENT_GRACE:
-            return
+    def _rollover(self, session, season) -> Season:
+        """Void unresolved markets, record final standings, archive the season, and start the next."""
         for market in session.query(Market).filter(Market.season_id == season.id, Market.status == "OPEN").all():
             self._resolve_market(session, market, "void")
         accounts = session.query(PlayerAccount).all()
         for rank, account in enumerate(sorted(accounts, key=lambda a: a.balance, reverse=True), start=1):
             session.add(SeasonResult(season_id=season.id, user_id=account.id, final_balance=account.balance, rank=rank))
         season.status = "archived"
-        next_season = self._new_season(session, starts_at=season.ends_at)  # keep the calendar alignment even if settlement ran late
+        next_season = self._new_season(session, starts_at=season.ends_at)  # keep the calendar alignment
         for account in accounts:
             account.balance = 0
             self._credit(session, next_season.id, account, None, config.STARTING_BALANCE, "season_grant")
+        return next_season
 
     def _new_season(self, session, starts_at=None) -> Season:
         starts_at = starts_at or now()

--- a/duckbot/cogs/playmarket/models.py
+++ b/duckbot/cogs/playmarket/models.py
@@ -20,15 +20,27 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _next_quarter_start(dt: datetime) -> datetime:
+    """Midnight on the first day of the calendar quarter following dt."""
+    month = (dt.month - 1) // 3 * 3 + 4
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    return dt.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
 class Season(Base):
     __tablename__ = "pm_seasons"
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
     starts_at = Column(DateTime(timezone=True), nullable=False)
-    ends_at = Column(DateTime(timezone=True), nullable=False)
     status = Column(String, nullable=False, default="active")  # active|settling|archived
     starting_balance = Column(BigInteger, nullable=False, default=10000)
+
+    @property
+    def ends_at(self) -> datetime:
+        """A season always spans exactly one calendar quarter from its start."""
+        return _next_quarter_start(self.starts_at)
 
 
 class PlayerAccount(Base):

--- a/duckbot/cogs/playmarket/models.py
+++ b/duckbot/cogs/playmarket/models.py
@@ -34,7 +34,7 @@ class Season(Base):
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
     starts_at = Column(DateTime(timezone=True), nullable=False)
-    status = Column(String, nullable=False, default="active")  # active|settling|archived
+    status = Column(String, nullable=False, default="active")  # active|archived
     starting_balance = Column(BigInteger, nullable=False, default=10000)
 
     @property

--- a/duckbot/db/migrations/versions/004_quarterly_seasons.py
+++ b/duckbot/db/migrations/versions/004_quarterly_seasons.py
@@ -1,0 +1,34 @@
+"""quarterly seasons
+
+Revision ID: 004_quarterly_seasons
+Revises: 003_playmarket
+Create Date: 2026-07-09
+
+"""
+
+from datetime import datetime
+from typing import Sequence, Union
+from zoneinfo import ZoneInfo
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004_quarterly_seasons"
+down_revision: Union[str, None] = "003_playmarket"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Season.ends_at is now derived from starts_at (see models._next_quarter_start), so the column is
+# redundant. Reset the currently running season's clock to roughly now, so it lands on the next
+# quarter boundary (2026-10-01) instead of whatever the old ~6-month timedelta happened to leave it at.
+RESTART = datetime(2026, 7, 9, tzinfo=ZoneInfo("US/Eastern"))
+
+
+def upgrade() -> None:
+    seasons = sa.table("pm_seasons", sa.column("status", sa.String), sa.column("starts_at", sa.DateTime(timezone=True)))
+    op.execute(seasons.update().where(seasons.c.status == "active").values(starts_at=RESTART))
+    op.drop_column("pm_seasons", "ends_at")
+
+
+def downgrade() -> None:
+    op.add_column("pm_seasons", sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True))

--- a/duckbot/db/migrations/versions/004_quarterly_seasons.py
+++ b/duckbot/db/migrations/versions/004_quarterly_seasons.py
@@ -24,6 +24,13 @@ depends_on: Union[str, Sequence[str], None] = None
 RESTART = datetime(2026, 7, 9, tzinfo=ZoneInfo("US/Eastern"))
 
 
+def _next_quarter_start(dt: datetime) -> datetime:
+    month = (dt.month - 1) // 3 * 3 + 4
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    return dt.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
 def upgrade() -> None:
     seasons = sa.table("pm_seasons", sa.column("status", sa.String), sa.column("starts_at", sa.DateTime(timezone=True)))
     op.execute(seasons.update().where(seasons.c.status == "active").values(starts_at=RESTART))
@@ -32,3 +39,9 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.add_column("pm_seasons", sa.Column("ends_at", sa.DateTime(timezone=True), nullable=True))
+    seasons = sa.table("pm_seasons", sa.column("id", sa.BigInteger), sa.column("starts_at", sa.DateTime(timezone=True)), sa.column("ends_at", sa.DateTime(timezone=True)))
+    conn = op.get_bind()
+    for sid, starts_at in conn.execute(sa.select(seasons.c.id, seasons.c.starts_at)):
+        conn.execute(seasons.update().where(seasons.c.id == sid).values(ends_at=_next_quarter_start(starts_at)))
+    with op.batch_alter_table("pm_seasons") as batch:
+        batch.alter_column("ends_at", nullable=False)

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -219,7 +219,7 @@ async def test_create_sets_liquidity_and_subsidy_by_tier(cog, alice, in_memory_d
 
 async def test_create_is_blocked_once_the_season_is_settling(cog, alice, clock):
     await open_market(cog, alice)  # creates Season 1
-    clock.advance(days=183)  # past the season end
+    clock.advance(days=91)  # past the season end (2024-01-01 -> next quarter start 2024-04-01)
     await cog.create(alice, "Q", "med")
     assert alice.send.call_args.args[0] == "Season's wrapping up, no new markets. Pump the brakes."
 
@@ -545,7 +545,7 @@ async def test_standings_splits_cash_and_shares_value(cog, bob, in_memory_db):
 
 async def test_rollover_archives_the_season_and_starts_the_next(cog, alice, clock, in_memory_db):
     await open_market(cog, alice)
-    clock.advance(days=190)  # past the season end plus the 7-day grace
+    clock.advance(days=98)  # past the season end (2024-04-01) plus the 7-day grace
     await cog.tick()
     with in_memory_db.session(Season) as session:
         statuses = {s.name: s.status for s in session.query(Season).all()}
@@ -556,7 +556,7 @@ async def test_rollover_resets_every_balance(cog, alice, bob, clock, in_memory_d
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
     await cog.balance(bob)
-    clock.advance(days=190)
+    clock.advance(days=98)
     await cog.tick()
     assert account(in_memory_db, 1).balance == STARTING
     assert account(in_memory_db, 2).balance == STARTING
@@ -565,7 +565,7 @@ async def test_rollover_resets_every_balance(cog, alice, bob, clock, in_memory_d
 async def test_rollover_force_voids_unsettled_markets(cog, alice, clock, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
-    clock.advance(days=190)
+    clock.advance(days=98)
     await cog.tick()
     assert market_row(in_memory_db, market_id).status == "VOID"
 
@@ -573,7 +573,7 @@ async def test_rollover_force_voids_unsettled_markets(cog, alice, clock, in_memo
 async def test_rollover_records_the_final_standings(cog, alice, bob, clock, in_memory_db):
     await cog.balance(alice)
     await cog.balance(bob)
-    clock.advance(days=190)
+    clock.advance(days=98)
     await cog.tick()
     with in_memory_db.session(Season) as session:
         season_one = session.query(Season).filter_by(name="Season 1").one()

--- a/tests/cogs/playmarket/market_test.py
+++ b/tests/cogs/playmarket/market_test.py
@@ -217,11 +217,14 @@ async def test_create_sets_liquidity_and_subsidy_by_tier(cog, alice, in_memory_d
     assert market.subsidy == math.floor(b * math.log(2))
 
 
-async def test_create_is_blocked_once_the_season_is_settling(cog, alice, clock):
+async def test_create_after_season_end_rolls_over_first(cog, alice, clock, in_memory_db):
     await open_market(cog, alice)  # creates Season 1
     clock.advance(days=91)  # past the season end (2024-01-01 -> next quarter start 2024-04-01)
-    await cog.create(alice, "Q", "med")
-    assert alice.send.call_args.args[0] == "Season's wrapping up, no new markets. Pump the brakes."
+    market_id = await open_market(cog, alice)
+    with in_memory_db.session(Season) as session:
+        statuses = {s.name: s.status for s in session.query(Season).all()}
+    assert statuses == {"Season 1": "archived", "Season 2": "active"}
+    assert market_row(in_memory_db, market_id).season_id == 2
 
 
 # --- bet -----------------------------------------------------------------
@@ -545,7 +548,7 @@ async def test_standings_splits_cash_and_shares_value(cog, bob, in_memory_db):
 
 async def test_rollover_archives_the_season_and_starts_the_next(cog, alice, clock, in_memory_db):
     await open_market(cog, alice)
-    clock.advance(days=98)  # past the season end (2024-04-01) plus the 7-day grace
+    clock.advance(days=91)  # past the season end (2024-01-01 -> 2024-04-01)
     await cog.tick()
     with in_memory_db.session(Season) as session:
         statuses = {s.name: s.status for s in session.query(Season).all()}
@@ -556,7 +559,7 @@ async def test_rollover_resets_every_balance(cog, alice, bob, clock, in_memory_d
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
     await cog.balance(bob)
-    clock.advance(days=98)
+    clock.advance(days=91)
     await cog.tick()
     assert account(in_memory_db, 1).balance == STARTING
     assert account(in_memory_db, 2).balance == STARTING
@@ -565,7 +568,7 @@ async def test_rollover_resets_every_balance(cog, alice, bob, clock, in_memory_d
 async def test_rollover_force_voids_unsettled_markets(cog, alice, clock, in_memory_db):
     market_id = await open_market(cog, alice)
     await cog.bet(alice, market_id, "yes", BET)
-    clock.advance(days=98)
+    clock.advance(days=91)
     await cog.tick()
     assert market_row(in_memory_db, market_id).status == "VOID"
 
@@ -573,7 +576,7 @@ async def test_rollover_force_voids_unsettled_markets(cog, alice, clock, in_memo
 async def test_rollover_records_the_final_standings(cog, alice, bob, clock, in_memory_db):
     await cog.balance(alice)
     await cog.balance(bob)
-    clock.advance(days=98)
+    clock.advance(days=91)
     await cog.tick()
     with in_memory_db.session(Season) as session:
         season_one = session.query(Season).filter_by(name="Season 1").one()

--- a/tests/cogs/playmarket/market_unit_test.py
+++ b/tests/cogs/playmarket/market_unit_test.py
@@ -4,14 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from duckbot.cogs.playmarket.market import (
-    PlayMarket,
-    _coins,
-    _down,
-    _next_quarter_start,
-    _pct,
-    _whole,
-)
+from duckbot.cogs.playmarket.market import PlayMarket, _coins, _down, _pct, _whole
+from duckbot.cogs.playmarket.models import _next_quarter_start
 
 
 @pytest.fixture

--- a/tests/cogs/playmarket/market_unit_test.py
+++ b/tests/cogs/playmarket/market_unit_test.py
@@ -1,9 +1,17 @@
+import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
 
-from duckbot.cogs.playmarket.market import PlayMarket, _coins, _down, _pct, _whole
+from duckbot.cogs.playmarket.market import (
+    PlayMarket,
+    _coins,
+    _down,
+    _next_quarter_start,
+    _pct,
+    _whole,
+)
 
 
 @pytest.fixture
@@ -68,3 +76,20 @@ def test_coins_are_shown_as_whole_numbers(value, shown):
 @pytest.mark.parametrize("probability,shown", [(0.5, "50%"), (0.697, "69.7%"), (0.0, "0%"), (1.0, "100%"), (0.0193, "1.93%")])
 def test_prices_keep_a_few_decimal_places(probability, shown):
     assert _pct(probability) == shown
+
+
+# --- quarter alignment -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dt,expected",
+    [
+        (datetime.datetime(2024, 1, 1, 12, 0), datetime.datetime(2024, 4, 1)),
+        (datetime.datetime(2024, 3, 31, 23, 59), datetime.datetime(2024, 4, 1)),
+        (datetime.datetime(2024, 4, 1, 0, 0), datetime.datetime(2024, 7, 1)),
+        (datetime.datetime(2024, 10, 15), datetime.datetime(2025, 1, 1)),
+        (datetime.datetime(2024, 12, 31, 23, 59), datetime.datetime(2025, 1, 1)),
+    ],
+)
+def test_next_quarter_start_lands_on_the_following_quarter(dt, expected):
+    assert _next_quarter_start(dt) == expected

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -28,7 +28,7 @@ Every command works as both a slash command (`/market bet`) and a prefix command
 
 ## Coins and seasons
 
-Everyone starts each **season** with **10,000 coins**. A season lasts about six months, after which balances reset and a fresh leaderboard begins — so a cold streak is never permanent and everyone re-levels.
+Everyone starts each **season** with **10,000 coins**. A season runs for a calendar quarter, resetting on the first day of January, April, July, and October, after which balances reset and a fresh leaderboard begins — so a cold streak is never permanent and everyone re-levels.
 
 - Coins are always **whole numbers**. (Share counts can be fractional under the hood — that's the market's internal accounting — but you bet and get paid in whole coins.)
 - Coins are spent placing bets and earned when your bets pay out.
@@ -140,7 +140,7 @@ Only the creator can resolve their own market — it's a friends-trust-friends "
 | Thing             | Value                                                    |
 | ----------------- | -------------------------------------------------------- |
 | Starting balance  | 10,000 coins per season                                  |
-| Season length     | ~6 months, then balances reset                           |
+| Season length     | 1 calendar quarter, then balances reset                  |
 | Need-based top-up | under 1,000 coins & no positions → back to 2,000, weekly |
 | Minimum bet       | 10 coins                                                 |
 | Resolution        | by the market's creator; auto-void at season end         |

--- a/wiki/Prediction-Market.md
+++ b/wiki/Prediction-Market.md
@@ -33,7 +33,7 @@ Everyone starts each **season** with **10,000 coins**. A season runs for a calen
 - Coins are always **whole numbers**. (Share counts can be fractional under the hood — that's the market's internal accounting — but you bet and get paid in whole coins.)
 - Coins are spent placing bets and earned when your bets pay out.
 - If you go broke (under 1,000 coins) **and** hold no open positions, `/market claim` tops you back up to 2,000 coins, once per week. It's the only faucet, so balances still track skill within a season.
-- At season end there's a 7-day grace period for open markets to resolve, then balances reset and the final standings are recorded in a hall of fame.
+- At season end any still-open markets are auto-voided, balances reset, and the final standings are recorded in a hall of fame.
 
 Use `/market balance` to see your coins and positions, and `/market leaderboard` for the standings (ranked by net worth = coins + the live value of your open positions).
 


### PR DESCRIPTION
##### Summary

Season length was a rolling ~6 month timedelta from whenever the season was created. This changes it so seasons reset on the first day of each calendar quarter (Jan 1, Apr 1, Jul 1, Oct 1) instead.

New seasons align to the calendar even across rollovers: each new season's `starts_at` is chained to the previous season's `ends_at` (an exact quarter boundary). `Season.ends_at` is now a derived property instead of a stored column, since it's always just the next quarter boundary after `starts_at`. A migration drops the old `ends_at` column and resets the currently-active season to end on 2026-10-01.

Also drops the 7-day settlement grace period — seasons now roll over (void open markets, archive, start the next) the instant a quarter boundary passes, rather than sitting in a "settling" limbo first.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root
  - [x] fixes #1406
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change