### PR TITLE
:sparkles: monthly Friend Facts server stats report

### DIFF
--- a/duckbot/cogs/messages/__init__.py
+++ b/duckbot/cogs/messages/__init__.py
@@ -1,4 +1,5 @@
 from .edit_diff import EditDiff
+from .friend_facts import FriendFacts
 from .haiku import Haiku
 from .touch_grass import TouchGrass
 from .typing import Typing
@@ -6,6 +7,7 @@ from .typing import Typing
 
 async def setup(bot):
     await bot.add_cog(EditDiff())
+    await bot.add_cog(FriendFacts(bot))
     await bot.add_cog(Haiku())
     await bot.add_cog(TouchGrass(bot))
     await bot.add_cog(Typing(bot))

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -21,6 +21,9 @@ class UserStats:
     questions: int = 0
     shouts: int = 0
     links: int = 0
+    golf: int = 0
+    weather: int = 0
+    mentions: int = 0
 
 
 class FriendFacts(commands.Cog):
@@ -72,7 +75,9 @@ class FriendFacts(commands.Cog):
                 continue
             try:
                 async for message in channel.history(limit=None, after=start, before=end, oldest_first=True):
-                    if not message.author.bot:
+                    if message.author.bot:
+                        self.tally_slash_weather(stats, message)
+                    else:
                         self.tally(stats, hours, days, message)
                 channels += 1
             except Forbidden:
@@ -88,9 +93,26 @@ class FriendFacts(commands.Cog):
         user.questions += content.rstrip().endswith("?")
         user.shouts += content.isupper() and any(c.isalpha() for c in content)
         user.links += "http" in content
+        user.golf += content.lower().count("golf")
+        user.weather += content.lower().startswith("!weather")
+        user.mentions += self.mention_count(message)
         created = message.created_at.astimezone(duckbot.util.datetime.timezone())
         hours[created.hour] += 1
         days[created.weekday()] += 1
+
+    def tally_slash_weather(self, stats, message: Message):
+        """Slash invocations show up as bot messages; credit /weather to the invoker."""
+        interaction = message.interaction
+        if interaction and interaction.name.split()[0] == "weather":
+            stats.setdefault(interaction.user.id, UserStats()).weather += 1
+
+    def mention_count(self, message: Message):
+        mentioned = {user.id for user in message.mentions}
+        replied = message.reference.resolved if message.reference else None
+        if isinstance(replied, Message):
+            mentioned.add(replied.author.id)
+        mentioned.discard(message.author.id)
+        return len(mentioned)
 
     async def format_report(self, guild, stats, hours, days, channels, start):
         header = f"**Friend Facts: {start:%B %Y}** :bar_chart:"
@@ -116,13 +138,17 @@ class FriendFacts(commands.Cog):
             lines.append(f":books: Wordiest: {await self.display_name(guild, user_id)} — {user.words / user.messages:.1f} words per message")
             user_id, user = max(regulars.items(), key=lambda x: x[1].questions / x[1].messages)
             lines.append(f":question: Most Inquisitive: {await self.display_name(guild, user_id)} — {100 * user.questions // user.messages}% of messages are questions")
-        user_id, user = max(stats.items(), key=lambda x: x[1].shouts)
-        if user.shouts:
-            lines.append(f":loudspeaker: Loudest: {await self.display_name(guild, user_id)} — {user.shouts} ALL-CAPS messages")
-        user_id, user = max(stats.items(), key=lambda x: x[1].links)
-        if user.links:
-            lines.append(f":link: Chief Link Dumper: {await self.display_name(guild, user_id)} — {user.links} links shared")
+        lines += await self.count_award(guild, stats, "shouts", ":loudspeaker: Loudest: {name} — {count} ALL-CAPS messages")
+        lines += await self.count_award(guild, stats, "links", ":link: Chief Link Dumper: {name} — {count} links shared")
+        lines += await self.count_award(guild, stats, "golf", ":golf: Golf Fanatic: {name} — {count} golf mentions")
+        lines += await self.count_award(guild, stats, "weather", ":white_sun_small_cloud: Weather Obsessed: {name} — {count} weather checks")
+        lines += await self.count_award(guild, stats, "mentions", ":wave: Name Dropper: {name} — {count} people mentioned")
         return lines
+
+    async def count_award(self, guild, stats, attr, template):
+        user_id, user = max(stats.items(), key=lambda x: getattr(x[1], attr))
+        count = getattr(user, attr)
+        return [template.format(name=await self.display_name(guild, user_id), count=count)] if count else []
 
     async def display_name(self, guild, user_id):
         user = await get_user(self.bot, user_id, guild)

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -123,7 +123,7 @@ class FriendFacts(commands.Cog):
         lines = [header, "```", f"{'User':<24} {'Messages':>8}", "-" * 34]
         top = sorted(stats.items(), key=lambda x: x[1].messages, reverse=True)
         for user_id, user in top[:LEADERBOARD_SIZE]:
-            lines.append(f"{await self.display_name(guild, user_id):<24} {user.messages:>8}")
+            lines.append(f"{(await self.display_name(guild, user_id))[:24]:<24} {user.messages:>8}")
         lines.append("```")
         lines.append(f":pencil: {sum(u.messages for u in stats.values()):,} messages across {channels} channels")
         lines += await self.awards(guild, stats)

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -1,0 +1,132 @@
+import calendar
+from dataclasses import dataclass
+from datetime import time, timedelta
+
+from discord import ChannelType, Forbidden, Message
+from discord.ext import commands, tasks
+from discord.utils import get
+
+import duckbot.util.datetime
+from duckbot.util.users import get_user
+
+LEADERBOARD_SIZE = 10
+MIN_MESSAGES_FOR_AWARD = 25
+
+
+@dataclass
+class UserStats:
+    messages: int = 0
+    words: int = 0
+    capital_starts: int = 0
+    questions: int = 0
+    shouts: int = 0
+    links: int = 0
+
+
+class FriendFacts(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.friend_facts_loop.start()
+
+    def cog_unload(self):
+        self.friend_facts_loop.cancel()
+
+    def get_general_channel(self):
+        return get(self.bot.get_all_channels(), guild__name="Friends Chat", name="general", type=ChannelType.text)
+
+    @tasks.loop(time=time(hour=9, minute=0, tzinfo=duckbot.util.datetime.timezone()))
+    async def friend_facts_loop(self):
+        await self.on_month_start()
+
+    @friend_facts_loop.before_loop
+    async def before_loop(self):
+        await self.bot.wait_until_ready()
+
+    async def on_month_start(self):
+        if duckbot.util.datetime.now().day == 1:
+            await self.send_report()
+
+    @commands.command(name="friend-facts")
+    async def friend_facts(self, context):
+        await self.send_report()
+
+    def prior_month_range(self):
+        end = duckbot.util.datetime.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        start = (end - timedelta(days=1)).replace(day=1)
+        return start, end
+
+    async def send_report(self):
+        channel = self.get_general_channel()
+        start, end = self.prior_month_range()
+        stats, hours, days, channels = await self.gather_stats(channel.guild, start, end)
+        await channel.send(await self.format_report(channel.guild, stats, hours, days, channels, start))
+
+    async def gather_stats(self, guild, start, end):
+        """Streams message history into counters; messages are never kept in memory."""
+        stats = {}
+        hours = [0] * 24
+        days = [0] * 7
+        channels = 0
+        for channel in guild.text_channels:
+            if not channel.permissions_for(guild.me).read_message_history:
+                continue
+            try:
+                async for message in channel.history(limit=None, after=start, before=end, oldest_first=True):
+                    if not message.author.bot:
+                        self.tally(stats, hours, days, message)
+                channels += 1
+            except Forbidden:
+                pass
+        return stats, hours, days, channels
+
+    def tally(self, stats, hours, days, message: Message):
+        user = stats.setdefault(message.author.id, UserStats())
+        content = message.content
+        user.messages += 1
+        user.words += len(content.split())
+        user.capital_starts += content[:1].isupper()
+        user.questions += content.rstrip().endswith("?")
+        user.shouts += content.isupper() and any(c.isalpha() for c in content)
+        user.links += "http" in content
+        created = message.created_at.astimezone(duckbot.util.datetime.timezone())
+        hours[created.hour] += 1
+        days[created.weekday()] += 1
+
+    async def format_report(self, guild, stats, hours, days, channels, start):
+        header = f"**Friend Facts: {start:%B %Y}** :bar_chart:"
+        if not stats:
+            return f"{header}\nNobody said anything last month. :duck:"
+        lines = [header, "```", f"{'User':<24} {'Messages':>8}", "-" * 34]
+        top = sorted(stats.items(), key=lambda x: x[1].messages, reverse=True)
+        for user_id, user in top[:LEADERBOARD_SIZE]:
+            lines.append(f"{await self.display_name(guild, user_id):<24} {user.messages:>8}")
+        lines.append("```")
+        lines.append(f":pencil: {sum(u.messages for u in stats.values()):,} messages across {channels} channels")
+        lines += await self.awards(guild, stats)
+        lines.append(f":crescent_moon: Busiest hour: {self.hour_name(hours.index(max(hours)))} · Busiest day: {calendar.day_name[days.index(max(days))]}")
+        return "\n".join(lines)
+
+    async def awards(self, guild, stats):
+        lines = []
+        regulars = {k: v for k, v in stats.items() if v.messages >= MIN_MESSAGES_FOR_AWARD}
+        if regulars:
+            user_id, user = max(regulars.items(), key=lambda x: x[1].capital_starts / x[1].messages)
+            lines.append(f":tophat: Grammar Police: {await self.display_name(guild, user_id)} — {100 * user.capital_starts // user.messages}% of messages start with a capital")
+            user_id, user = max(regulars.items(), key=lambda x: x[1].words / x[1].messages)
+            lines.append(f":books: Wordiest: {await self.display_name(guild, user_id)} — {user.words / user.messages:.1f} words per message")
+            user_id, user = max(regulars.items(), key=lambda x: x[1].questions / x[1].messages)
+            lines.append(f":question: Most Inquisitive: {await self.display_name(guild, user_id)} — {100 * user.questions // user.messages}% of messages are questions")
+        user_id, user = max(stats.items(), key=lambda x: x[1].shouts)
+        if user.shouts:
+            lines.append(f":loudspeaker: Loudest: {await self.display_name(guild, user_id)} — {user.shouts} ALL-CAPS messages")
+        user_id, user = max(stats.items(), key=lambda x: x[1].links)
+        if user.links:
+            lines.append(f":link: Chief Link Dumper: {await self.display_name(guild, user_id)} — {user.links} links shared")
+        return lines
+
+    async def display_name(self, guild, user_id):
+        user = await get_user(self.bot, user_id, guild)
+        return user.display_name if user else f"User-{user_id}"
+
+    def hour_name(self, hour):
+        return f"{hour % 12 or 12}{'am' if hour < 12 else 'pm'}"

--- a/duckbot/cogs/messages/friend_facts.py
+++ b/duckbot/cogs/messages/friend_facts.py
@@ -24,6 +24,7 @@ class UserStats:
     golf: int = 0
     weather: int = 0
     mentions: int = 0
+    attachments: int = 0
 
 
 class FriendFacts(commands.Cog):
@@ -96,6 +97,7 @@ class FriendFacts(commands.Cog):
         user.golf += content.lower().count("golf")
         user.weather += content.lower().startswith("!weather")
         user.mentions += self.mention_count(message)
+        user.attachments += len(message.attachments)
         created = message.created_at.astimezone(duckbot.util.datetime.timezone())
         hours[created.hour] += 1
         days[created.weekday()] += 1
@@ -143,6 +145,7 @@ class FriendFacts(commands.Cog):
         lines += await self.count_award(guild, stats, "golf", ":golf: Golf Fanatic: {name} — {count} golf mentions")
         lines += await self.count_award(guild, stats, "weather", ":white_sun_small_cloud: Weather Obsessed: {name} — {count} weather checks")
         lines += await self.count_award(guild, stats, "mentions", ":wave: Name Dropper: {name} — {count} people mentioned")
+        lines += await self.count_award(guild, stats, "attachments", ":camera: Paparazzi: {name} — {count} attachments sent")
         return lines
 
     async def count_award(self, guild, stats, attr, template):

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import mock
 
+import discord
 import pytest
 from discord import Forbidden
 
@@ -15,13 +16,30 @@ def clazz(bot) -> FriendFacts:
     return bind_commands(FriendFacts(bot))
 
 
-def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc)):
+def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc), mentions=[], reference=None):
     message = mock.Mock()
     message.author.id = author_id
     message.author.bot = is_bot
     message.content = content
     message.created_at = created_at
+    message.mentions = mentions
+    message.reference = reference
+    message.interaction = None
     return message
+
+
+def make_user(user_id):
+    user = mock.Mock()
+    user.id = user_id
+    return user
+
+
+def make_reply_to(author_id):
+    replied = mock.Mock(spec=discord.Message)
+    replied.author.id = author_id
+    reference = mock.Mock()
+    reference.resolved = replied
+    return reference
 
 
 def readable(channel, messages):
@@ -91,6 +109,19 @@ async def test_gather_stats_skips_bot_messages(clazz, guild, text_channel):
     assert stats == {}
 
 
+async def test_gather_stats_credits_slash_weather_to_invoker(clazz, guild, text_channel):
+    invocation = make_message(is_bot=True)
+    invocation.interaction = mock.Mock()
+    invocation.interaction.name = "weather get"
+    invocation.interaction.user.id = 5
+    other = make_message(is_bot=True)
+    other.interaction = mock.Mock()
+    other.interaction.name = "market bet"
+    guild.text_channels = [readable(text_channel, [invocation, other])]
+    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    assert stats == {5: UserStats(weather=1)}
+
+
 async def test_gather_stats_skips_unreadable_channels(clazz, guild, text_channel):
     text_channel.permissions_for.return_value.read_message_history = False
     guild.text_channels = [text_channel]
@@ -116,6 +147,37 @@ def test_tally_counts_each_stat(clazz):
     assert stats[1] == UserStats(messages=4, words=6, capital_starts=2, questions=1, shouts=1, links=1)
 
 
+def test_tally_counts_golf_mentions_case_insensitive(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message("GOLF golf golfing, hole in one"))
+    assert stats[1].golf == 3
+
+
+def test_tally_counts_weather_prefix_command(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message("!weather set london ca 2"))
+    clazz.tally(stats, hours, days, make_message("nice weather today"))
+    assert stats[1].weather == 1
+
+
+def test_tally_counts_mentions_and_replies_distinctly(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message("hi", mentions=[make_user(2), make_user(3)]))
+    clazz.tally(stats, hours, days, make_message("hi", reference=make_reply_to(2)))
+    clazz.tally(stats, hours, days, make_message("hi", mentions=[make_user(2)], reference=make_reply_to(2)))  # reply ping counts once
+    assert stats[1].mentions == 4
+
+
+def test_tally_mentions_excludes_self_and_deleted_replies(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    deleted = mock.Mock()
+    deleted.resolved = mock.Mock(spec=discord.DeletedReferencedMessage)
+    clazz.tally(stats, hours, days, make_message("hi", mentions=[make_user(1)]))
+    clazz.tally(stats, hours, days, make_message("hi", reference=make_reply_to(1)))
+    clazz.tally(stats, hours, days, make_message("hi", reference=deleted))
+    assert stats[1].mentions == 0
+
+
 def test_tally_buckets_hours_and_days_in_eastern_time(clazz):
     stats, hours, days = {}, [0] * 24, [0] * 7
     clazz.tally(stats, hours, days, make_message(created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc)))  # 2:30pm EDT, a Monday
@@ -133,8 +195,8 @@ async def test_format_report_empty_month(get_user, clazz, guild):
 async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {
-        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7),
-        2: UserStats(messages=30, words=300, capital_starts=6, questions=15),
+        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7, golf=12),
+        2: UserStats(messages=30, words=300, capital_starts=6, questions=15, weather=9, mentions=21),
     }
     hours = [0] * 24
     hours[23] = 42
@@ -149,6 +211,9 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     assert "Most Inquisitive: user2 — 50% of messages are questions" in report
     assert "Loudest: user1 — 3 ALL-CAPS messages" in report
     assert "Chief Link Dumper: user1 — 7 links shared" in report
+    assert "Golf Fanatic: user1 — 12 golf mentions" in report
+    assert "Weather Obsessed: user2 — 9 weather checks" in report
+    assert "Name Dropper: user2 — 21 people mentioned" in report
     assert "Busiest hour: 11pm · Busiest day: Saturday" in report
 
 
@@ -178,6 +243,9 @@ async def test_format_report_no_awards_for_zero_counts(get_user, clazz, guild):
     report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
     assert "Loudest" not in report
     assert "Chief Link Dumper" not in report
+    assert "Golf Fanatic" not in report
+    assert "Weather Obsessed" not in report
+    assert "Name Dropper" not in report
 
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user", return_value=None)

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -236,6 +236,14 @@ async def test_format_report_truncates_leaderboard_to_top_ten(get_user, clazz, g
 
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_truncates_long_names_in_leaderboard(get_user, clazz, guild):
+    get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name="a" * 32)
+    report = await clazz.format_report(guild, {1: UserStats(messages=5)}, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    assert "a" * 24 + " " in report
+    assert "a" * 25 not in report
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
 async def test_format_report_awards_require_minimum_messages(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {1: UserStats(messages=1, words=50, capital_starts=1, questions=1), 2: UserStats(messages=25, words=25, capital_starts=5, questions=5)}

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -1,0 +1,196 @@
+import datetime
+from unittest import mock
+
+import pytest
+from discord import Forbidden
+
+from duckbot.cogs.messages import FriendFacts
+from duckbot.cogs.messages.friend_facts import UserStats
+from tests.async_mock_ext import list_as_async_generator
+from tests.discord_test_ext import bind_commands
+
+
+@pytest.fixture
+def clazz(bot) -> FriendFacts:
+    return bind_commands(FriendFacts(bot))
+
+
+def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc)):
+    message = mock.Mock()
+    message.author.id = author_id
+    message.author.bot = is_bot
+    message.content = content
+    message.created_at = created_at
+    return message
+
+
+def readable(channel, messages):
+    channel.permissions_for.return_value.read_message_history = True
+    channel.history.return_value = list_as_async_generator(messages)
+    return channel
+
+
+async def test_before_loop_waits_for_bot(clazz, bot):
+    await clazz.before_loop()
+    bot.wait_until_ready.assert_called()
+
+
+def test_cog_unload_cancels_task(clazz):
+    clazz.cog_unload()
+    clazz.friend_facts_loop.cancel.assert_called()
+
+
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2026, 7, 1, hour=9))
+async def test_on_month_start_first_of_month_sends_report(now, clazz, guild, general_channel):
+    guild.text_channels = []
+    await clazz.on_month_start()
+    general_channel.send.assert_called_once()
+
+
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2026, 7, 2, hour=9))
+async def test_on_month_start_not_first_of_month_does_nothing(now, clazz, bot):
+    await clazz.on_month_start()
+    bot.get_all_channels.assert_not_called()
+
+
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2026, 7, 1, hour=9))
+async def test_friend_facts_command_sends_report(now, clazz, guild, general_channel, context):
+    guild.text_channels = []
+    await clazz.friend_facts(context)
+    general_channel.send.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "today, expected_start, expected_end",
+    [
+        (datetime.datetime(2026, 7, 10, hour=13), datetime.datetime(2026, 6, 1), datetime.datetime(2026, 7, 1)),
+        (datetime.datetime(2026, 1, 1, hour=9), datetime.datetime(2025, 12, 1), datetime.datetime(2026, 1, 1)),
+        (datetime.datetime(2026, 3, 31, hour=23), datetime.datetime(2026, 2, 1), datetime.datetime(2026, 3, 1)),
+    ],
+)
+@mock.patch("duckbot.util.datetime.now")
+def test_prior_month_range(now, clazz, today, expected_start, expected_end):
+    now.return_value = today
+    start, end = clazz.prior_month_range()
+    assert start == expected_start
+    assert end == expected_end
+
+
+async def test_gather_stats_streams_counters(clazz, guild, text_channel):
+    guild.text_channels = [readable(text_channel, [make_message("Hello there friend"), make_message("are you ok?", author_id=2)])]
+    stats, hours, days, channels = await clazz.gather_stats(guild, None, None)
+    assert stats[1] == UserStats(messages=1, words=3, capital_starts=1)
+    assert stats[2] == UserStats(messages=1, words=3, questions=1)
+    assert sum(hours) == 2 and sum(days) == 2
+    assert channels == 1
+
+
+async def test_gather_stats_skips_bot_messages(clazz, guild, text_channel):
+    guild.text_channels = [readable(text_channel, [make_message(is_bot=True)])]
+    stats, _, _, _ = await clazz.gather_stats(guild, None, None)
+    assert stats == {}
+
+
+async def test_gather_stats_skips_unreadable_channels(clazz, guild, text_channel):
+    text_channel.permissions_for.return_value.read_message_history = False
+    guild.text_channels = [text_channel]
+    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0
+    text_channel.history.assert_not_called()
+
+
+async def test_gather_stats_skips_forbidden_channels(clazz, guild, text_channel):
+    text_channel.permissions_for.return_value.read_message_history = True
+    text_channel.history.side_effect = Forbidden(mock.Mock(status=403), "no")
+    guild.text_channels = [text_channel]
+    stats, _, _, channels = await clazz.gather_stats(guild, None, None)
+    assert stats == {} and channels == 0
+
+
+def test_tally_counts_each_stat(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message("Hello world"))
+    clazz.tally(stats, hours, days, make_message("what? "))
+    clazz.tally(stats, hours, days, make_message("AAAH!"))
+    clazz.tally(stats, hours, days, make_message("see https://example.com"))
+    assert stats[1] == UserStats(messages=4, words=6, capital_starts=2, questions=1, shouts=1, links=1)
+
+
+def test_tally_buckets_hours_and_days_in_eastern_time(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message(created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc)))  # 2:30pm EDT, a Monday
+    assert hours[14] == 1
+    assert days[0] == 1
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_empty_month(get_user, clazz, guild):
+    report = await clazz.format_report(guild, {}, [0] * 24, [0] * 7, 0, datetime.datetime(2026, 6, 1))
+    assert report == "**Friend Facts: June 2026** :bar_chart:\nNobody said anything last month. :duck:"
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
+    get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
+    stats = {
+        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7),
+        2: UserStats(messages=30, words=300, capital_starts=6, questions=15),
+    }
+    hours = [0] * 24
+    hours[23] = 42
+    days = [0] * 7
+    days[5] = 42
+    report = await clazz.format_report(guild, stats, hours, days, 4, datetime.datetime(2026, 6, 1))
+    assert "**Friend Facts: June 2026**" in report
+    assert report.index("user1 ") < report.index("user2 ")
+    assert ":pencil: 80 messages across 4 channels" in report
+    assert "Grammar Police: user1 — 80% of messages start with a capital" in report
+    assert "Wordiest: user2 — 10.0 words per message" in report
+    assert "Most Inquisitive: user2 — 50% of messages are questions" in report
+    assert "Loudest: user1 — 3 ALL-CAPS messages" in report
+    assert "Chief Link Dumper: user1 — 7 links shared" in report
+    assert "Busiest hour: 11pm · Busiest day: Saturday" in report
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_truncates_leaderboard_to_top_ten(get_user, clazz, guild):
+    get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
+    stats = {i: UserStats(messages=100 - i) for i in range(1, 12)}
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    assert "user10 " in report
+    assert "user11 " not in report
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_awards_require_minimum_messages(get_user, clazz, guild):
+    get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
+    stats = {1: UserStats(messages=1, words=50, capital_starts=1, questions=1), 2: UserStats(messages=25, words=25, capital_starts=5, questions=5)}
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    assert "Grammar Police: user2" in report
+    assert "Wordiest: user2" in report
+    assert "Most Inquisitive: user2" in report
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user")
+async def test_format_report_no_awards_for_zero_counts(get_user, clazz, guild):
+    get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
+    stats = {1: UserStats(messages=5, words=10)}
+    report = await clazz.format_report(guild, stats, [0] * 24, [0] * 7, 1, datetime.datetime(2026, 6, 1))
+    assert "Loudest" not in report
+    assert "Chief Link Dumper" not in report
+
+
+@mock.patch("duckbot.cogs.messages.friend_facts.get_user", return_value=None)
+async def test_display_name_unknown_user(get_user, clazz, guild):
+    assert await clazz.display_name(guild, 123) == "User-123"
+
+
+@mock.patch("duckbot.util.datetime.now", return_value=datetime.datetime(2026, 7, 10, hour=13))
+async def test_send_report_posts_to_general_channel(now, clazz, guild, general_channel):
+    guild.text_channels = [readable(general_channel, [make_message("Hello")])]
+    with mock.patch("duckbot.cogs.messages.friend_facts.get_user", side_effect=lambda bot, user_id, g: mock.Mock(display_name=f"user{user_id}")):
+        await clazz.send_report()
+    general_channel.send.assert_called_once()
+    report = general_channel.send.call_args.args[0]
+    assert "**Friend Facts: June 2026**" in report
+    assert "user1 " in report

--- a/tests/cogs/messages/friend_facts_test.py
+++ b/tests/cogs/messages/friend_facts_test.py
@@ -16,7 +16,7 @@ def clazz(bot) -> FriendFacts:
     return bind_commands(FriendFacts(bot))
 
 
-def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc), mentions=[], reference=None):
+def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.datetime(2026, 6, 15, 18, 30, tzinfo=datetime.timezone.utc), mentions=[], reference=None, attachments=[]):
     message = mock.Mock()
     message.author.id = author_id
     message.author.bot = is_bot
@@ -25,6 +25,7 @@ def make_message(content="hi", author_id=1, is_bot=False, created_at=datetime.da
     message.mentions = mentions
     message.reference = reference
     message.interaction = None
+    message.attachments = attachments
     return message
 
 
@@ -160,6 +161,13 @@ def test_tally_counts_weather_prefix_command(clazz):
     assert stats[1].weather == 1
 
 
+def test_tally_counts_attachments(clazz):
+    stats, hours, days = {}, [0] * 24, [0] * 7
+    clazz.tally(stats, hours, days, make_message("look at these", attachments=[mock.Mock(), mock.Mock()]))
+    clazz.tally(stats, hours, days, make_message("no photos here"))
+    assert stats[1].attachments == 2
+
+
 def test_tally_counts_mentions_and_replies_distinctly(clazz):
     stats, hours, days = {}, [0] * 24, [0] * 7
     clazz.tally(stats, hours, days, make_message("hi", mentions=[make_user(2), make_user(3)]))
@@ -195,7 +203,7 @@ async def test_format_report_empty_month(get_user, clazz, guild):
 async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     get_user.side_effect = lambda bot, user_id, guild: mock.Mock(display_name=f"user{user_id}")
     stats = {
-        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7, golf=12),
+        1: UserStats(messages=50, words=100, capital_starts=40, questions=5, shouts=3, links=7, golf=12, attachments=33),
         2: UserStats(messages=30, words=300, capital_starts=6, questions=15, weather=9, mentions=21),
     }
     hours = [0] * 24
@@ -214,6 +222,7 @@ async def test_format_report_leaderboard_and_awards(get_user, clazz, guild):
     assert "Golf Fanatic: user1 — 12 golf mentions" in report
     assert "Weather Obsessed: user2 — 9 weather checks" in report
     assert "Name Dropper: user2 — 21 people mentioned" in report
+    assert "Paparazzi: user1 — 33 attachments sent" in report
     assert "Busiest hour: 11pm · Busiest day: Saturday" in report
 
 
@@ -246,6 +255,7 @@ async def test_format_report_no_awards_for_zero_counts(get_user, clazz, guild):
     assert "Golf Fanatic" not in report
     assert "Weather Obsessed" not in report
     assert "Name Dropper" not in report
+    assert "Paparazzi" not in report
 
 
 @mock.patch("duckbot.cogs.messages.friend_facts.get_user", return_value=None)

--- a/tests/cogs/messages/setup_test.py
+++ b/tests/cogs/messages/setup_test.py
@@ -1,4 +1,4 @@
-from duckbot.cogs.messages import EditDiff, Haiku, Typing
+from duckbot.cogs.messages import EditDiff, FriendFacts, Haiku, Typing
 from duckbot.cogs.messages import setup as extension_setup
 from tests.discord_test_ext import assert_cog_added_of_type
 
@@ -6,5 +6,6 @@ from tests.discord_test_ext import assert_cog_added_of_type
 async def test_setup(bot_spy):
     await extension_setup(bot_spy)
     assert_cog_added_of_type(bot_spy, EditDiff)
+    assert_cog_added_of_type(bot_spy, FriendFacts)
     assert_cog_added_of_type(bot_spy, Haiku)
     assert_cog_added_of_type(bot_spy, Typing)

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -40,7 +40,7 @@ DuckBot can define words, sourcing data from [Wordnik](https://www.wordnik.com/)
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, and Chief Link Dumper, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, and Name Dropper, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
 
 ## Recipe Search
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -40,7 +40,7 @@ DuckBot can define words, sourcing data from [Wordnik](https://www.wordnik.com/)
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, and Name Dropper, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, and Paparazzi, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
 
 ## Recipe Search
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -11,6 +11,7 @@
 |              `!dog`               | displays a random dog photo                        |
 |              `!duck`              | gives a link to this repo                          |
 |            `!fortune`             | get a random fortune told to you by a cow          |
+| [`!friend-facts`](#friend-facts)  | post last month's server stats report              |
 |        `!help` or `!wiki`         | gives a link to this wiki                          |
 |              `!lmgt`              | generates a google search link for the given query |
 |  [`/market`](Prediction-Market)   | bet on prediction markets, balances, leaderboard   |
@@ -36,6 +37,10 @@ Every day in the 7am hour, DuckBot will announce to the general channel the curr
 ## Definitions
 
 DuckBot can define words, sourcing data from [Wordnik](https://www.wordnik.com/). Inflected words resolve to their root word where possible.
+
+## Friend Facts
+
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, and Chief Link Dumper, along with the busiest hour and day. Percentage awards require at least 25 messages. You can run the report on demand with `!friend-facts`.
 
 ## Recipe Search
 

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -96,4 +96,4 @@ Every day in the 7am hour, DuckBot will announce to the general channel the curr
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, and Chief Link Dumper, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, and Name Dropper, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -93,3 +93,7 @@ DuckBot is a robot, and as such does not like being humanized. DuckBot tells peo
 ## Day Announcements
 
 Every day in the 7am hour, DuckBot will announce to the general channel the current day of the week. If the day is also a statutory holiday, or an otherwise special day, DuckBot will announce that at the same time. You can run this on demand using the `!day` command.
+
+## Friend Facts
+
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, and Chief Link Dumper, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.

--- a/wiki/Events.md
+++ b/wiki/Events.md
@@ -96,4 +96,4 @@ Every day in the 7am hour, DuckBot will announce to the general channel the curr
 
 ## Friend Facts
 
-On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, and Name Dropper, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.
+On the first of each month, DuckBot posts a stats report to the general channel covering the prior month's messages: a message-count leaderboard plus awards like Grammar Police (% of messages starting with a capital), Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, and Paparazzi, along with the busiest hour and day. You can run this on demand using the `!friend-facts` command.


### PR DESCRIPTION
##### Summary

Adds a `FriendFacts` cog to the `messages` package: on the 1st of each month (9am Eastern) it streams the prior calendar month of messages from every readable text channel and posts a stats report to #general — a top-10 message-count leaderboard plus awards (Grammar Police: % of messages starting with a capital, Wordiest, Most Inquisitive, Loudest, Chief Link Dumper, Golf Fanatic, Weather Obsessed, Name Dropper, Paparazzi: attachments sent) and the busiest hour/day. `!friend-facts` runs the report on demand.

Award notes:
- Percentage awards require ≥25 messages so a one-message wonder can't win at 100%.
- Weather Obsessed counts `!weather` prefix usage from message content, and `/weather` slash usage via the interaction metadata on the bot's response message (credited to the invoker).
- Name Dropper counts distinct people mentioned per message, via @ mentions or reply targets, excluding self-mentions.

History is aggregated with a bare `async for` into per-user integer counters (~9 ints per active user + 24/7 hour/day histograms), so no messages are held in memory — keeps the low-memory host happy.

Fork-first PR to iterate on before opening against duck-dynasty/duckbot (fixes duck-dynasty/duckbot#118).

Testing beyond unit tests: none yet — worth a live `!friend-facts` run in the test server.

##### Checklist

- [x] this is a source code change
  - [x] run `format` in the repository root
  - [x] run `pytest` in the repository root (satisfy solver tests skipped; they don't run on this machine)
  - [x] link to issue being fixed using a [_fixes keyword_](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), if such an issue exists
  - [x] update the wiki documentation if necessary
- [ ] or, this is **not** a source code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
